### PR TITLE
fix: make svgr mock produce better exports

### DIFF
--- a/config/jest/svgrMock.js
+++ b/config/jest/svgrMock.js
@@ -1,1 +1,4 @@
-module.exports = { ReactComponent: 'IconMock' };
+export const ReactComponent = 'IconMock';
+
+const mock = 'icon/mock/path';
+export default mock;


### PR DESCRIPTION
Technically this may break some snapshot tests that have codifed the wrong value for src.  But it should also make a warning go away during the test run, so… that seems better.