### PR TITLE
fix: update moduleSourceName to be @edx/frontend-platform/i18n

### DIFF
--- a/config/babel.config.js
+++ b/config/babel.config.js
@@ -32,7 +32,7 @@ module.exports = {
           'react-intl',
           {
             messagesDir: './temp/babel-plugin-react-intl',
-            moduleSourceName: '@edx/frontend-i18n',
+            moduleSourceName: '@edx/frontend-platform/i18n',
           },
         ],
       ],


### PR DESCRIPTION
Note that this will break translations for any repository using frontend-build and frontend-i18n.  Luckily, I don't think we have any of those.