### PR TITLE
feat: Allows adding an optimizely project ID into HtmlWebpackPlugin

### DIFF
--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -148,6 +148,7 @@ module.exports = Merge.smart(commonConfig, {
     new HtmlWebpackPlugin({
       inject: true, // Appends script tags linking to the webpack bundles at the end of the body
       template: path.resolve(process.cwd(), 'public/index.html'),
+      optimizelyId: process.env.OPTIMIZELY_PROJECT_ID || null,
     }),
     new Dotenv({
       path: path.resolve(process.cwd(), '.env'),


### PR DESCRIPTION
This allows projects that want to add optimizely to their headers to do so without overriding the HtmlWebpackPlugin configuration, which can be difficult and complicated (see frontend-app-payment’s webpack.prod.config.js for the difficulty in merging plugin configurations)