### PR TITLE
fix: adjust optimizelyId to OPTIMIZELY_PROJECT_ID

### DIFF
--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -148,7 +148,7 @@ module.exports = Merge.smart(commonConfig, {
     new HtmlWebpackPlugin({
       inject: true, // Appends script tags linking to the webpack bundles at the end of the body
       template: path.resolve(process.cwd(), 'public/index.html'),
-      optimizelyId: process.env.OPTIMIZELY_PROJECT_ID || null,
+      OPTIMIZELY_PROJECT_ID: process.env.OPTIMIZELY_PROJECT_ID || null,
     }),
     new Dotenv({
       path: path.resolve(process.cwd(), '.env'),


### PR DESCRIPTION
This way it’s easier to search for / connect the dots.

Nothing's using this yet, so this is more of a fix than a change that might break things.