### PR TITLE
feat: allow module.config.js for local module overrides

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,6 +102,33 @@ config file to a custom location, you may also need to customize references to i
 location in other configuration files. Please reach out to the FedX team if you
 need to do this and are running into problems.
 
+Local module configuration for Webpack
+--------------------------------------
+
+The development webpack configuration allows engineers to create a "module.config.js" file containing local module overrides.  This means that if you're developing a new feature in a shared library (@edx/frontend-platform, @edx/paragon, etc.), you can add the local location of that repository to your module.config.js file and the webpack build for your application will automatically pick it up and use it, rather than its node_modules version of the file.
+
+An example module.config.js file looks like the following.  You can copy this into your application to use local versions of paragon and frontend-platform::
+
+   module.exports = {
+      /*
+      Modules you want to use from local source code.  Adding a module here means that when this app
+      runs its build, it'll resolve the source from peer directories of this app.
+
+      moduleName: the name you use to import code from the module.
+      dir: The relative path to the module's source code.
+      dist: The sub-directory of the source code where it puts its build artifact.  Often "dist".
+      */
+      localModules: [
+         { moduleName: '@edx/paragon/scss', dir: '../paragon', dist: 'scss' },
+         { moduleName: '@edx/paragon', dir: '../paragon', dist: 'dist' },
+         { moduleName: '@edx/frontend-platform', dir: '../frontend-platform', dist: 'dist' },
+      ],
+   };
+
+Note that the "dir" and "dist" keys give you granular control over the shape of your repository's distribution.  Paragon, for instance, needs two separate entries to pick up both JS and SCSS imports.
+
+This mechanism uses Webpack resolve aliases, as documented here: https://webpack.js.org/configuration/resolve/#resolvealias
+
 Development
 -----------
 

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -17,6 +17,60 @@ dotenv.config({
   path: path.resolve(process.cwd(), '.env.development'),
 });
 
+/*
+This function reads in a 'module.config.js' file if it exists and uses its contents to define
+a set of webpack resolve.alias aliases for doing local development of application dependencies.
+It reads the package.json file of the dependency to determine if it has any peer dependencies, and
+then forces those peer dependencies to be resolved with the application's version.  Primarily, this
+is useful for making sure there's only one version of those dependencies loaded at once, which is a
+problem with both react and react-intl.
+
+The module.config.js file should have the form:
+
+{
+  localModules: [
+    { moduleName: 'nameOfPackage', dir: '../path/to/repo', dist: '/path/to/dist/in/repo' },
+    ... others...
+  ],
+}
+
+Some working examples, as of the time of this writing:
+
+{ moduleName: '@edx/paragon/scss', dir: '../paragon', dist: 'scss' }
+{ moduleName: '@edx/paragon', dir: '../paragon', dist: 'dist' }
+{ moduleName: '@edx/frontend-platform', dir: '../frontend-platform', dist: 'dist' }
+
+*/
+function getLocalAliases() {
+  const aliases = {};
+
+  try {
+    // eslint-disable-next-line import/no-dynamic-require, global-require
+    const { localModules } = require(path.resolve(process.cwd(), 'module.config.js'));
+
+    let allPeerDependencies = [];
+    const excludedPeerPackages = [];
+    localModules.forEach(({ moduleName, dir, dist = '' }) => {
+      // eslint-disable-next-line import/no-dynamic-require, global-require
+      const { peerDependencies, name } = require(path.resolve(process.cwd(), dir, 'package.json'));
+      allPeerDependencies = allPeerDependencies.concat(Object.keys(peerDependencies));
+      aliases[moduleName] = path.resolve(process.cwd(), dir, dist);
+      excludedPeerPackages.push(name);
+    });
+
+    allPeerDependencies = allPeerDependencies.filter((dep) => !excludedPeerPackages.includes(dep));
+
+    allPeerDependencies.forEach((dep) => {
+      aliases[dep] = path.resolve(process.cwd(), 'node_modules', dep);
+    });
+  } catch (e) {
+    console.log('No local module configuration file found. This is fine.');
+  }
+  return aliases;
+}
+
+const aliases = getLocalAliases();
+
 module.exports = Merge.smart(commonConfig, {
   mode: 'development',
   devtool: 'eval-source-map',
@@ -24,6 +78,9 @@ module.exports = Merge.smart(commonConfig, {
     // enable react's custom hot dev client so we get errors reported in the browser
     hot: require.resolve('react-dev-utils/webpackHotDevClient'),
     app: path.resolve(process.cwd(), 'src/index'),
+  },
+  resolve: {
+    alias: aliases,
   },
   module: {
     // Specify file-by-file rules to Webpack. Some file-types need a particular kind of loader.


### PR DESCRIPTION
Allows frontend applications to define a module.config.js file with local overrides for modules loaded by their application.  See details in the README.