### PR TITLE
Add capability to configure publicPath of webpack through environmental variables.

### DIFF
--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -12,7 +12,8 @@ const PostCssRtlPlugin = require('postcss-rtl');
 const commonConfig = require('./webpack.common.config.js');
 const presets = require('../lib/presets');
 
-// Add process env vars. Currently used only for setting the server port
+// Add process env vars. Currently used only for setting the
+// server port and the publicPath
 dotenv.config({
   path: path.resolve(process.cwd(), '.env.development'),
 });
@@ -78,6 +79,9 @@ module.exports = merge(commonConfig, {
     // enable react's custom hot dev client so we get errors reported in the browser
     hot: require.resolve('react-dev-utils/webpackHotDevClient'),
     app: path.resolve(process.cwd(), 'src/index'),
+  },
+  output: {
+    publicPath: process.env.PUBLIC_PATH || '/',
   },
   resolve: {
     alias: aliases,
@@ -202,6 +206,6 @@ module.exports = merge(commonConfig, {
     historyApiFallback: true,
     hot: true,
     inline: true,
-    publicPath: '/',
+    publicPath: process.env.PUBLIC_PATH || '/',
   },
 });

--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -2,6 +2,7 @@
 // optimized bundles at the expense of a longer build time.
 const { merge } = require('webpack-merge');
 const path = require('path');
+const dotenv = require('dotenv');
 const Dotenv = require('dotenv-webpack');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const HtmlWebpackNewRelicPlugin = require('html-webpack-new-relic-plugin');
@@ -15,12 +16,18 @@ const CssNano = require('cssnano');
 const commonConfig = require('./webpack.common.config.js');
 const presets = require('../lib/presets');
 
+// Add process env vars. Currently used only for setting the PUBLIC_PATH.
+dotenv.config({
+  path: path.resolve(process.cwd(), '.env'),
+});
+
 module.exports = merge(commonConfig, {
   mode: 'production',
   devtool: 'source-map',
   output: {
     filename: '[name].[chunkhash].js',
     path: path.resolve(process.cwd(), 'dist'),
+    publicPath: process.env.PUBLIC_PATH || '/',
   },
   module: {
     // Specify file-by-file rules to Webpack. Some file-types need a particular kind of loader.


### PR DESCRIPTION
This PR adds the capability to configure the [publicPath](https://webpack.js.org/guides/public-path/) webpack configuration through environmental variables in order to allow the deployment of MFEs in custom paths.