### PR TITLE
fix: Configure historyApiFallback to use publicPath

### DIFF
--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -71,6 +71,7 @@ function getLocalAliases() {
 }
 
 const aliases = getLocalAliases();
+const PUBLIC_PATH = process.env.PUBLIC_PATH || '/';
 
 module.exports = merge(commonConfig, {
   mode: 'development',
@@ -81,7 +82,7 @@ module.exports = merge(commonConfig, {
     app: path.resolve(process.cwd(), 'src/index'),
   },
   output: {
-    publicPath: process.env.PUBLIC_PATH || '/',
+    publicPath: PUBLIC_PATH,
   },
   resolve: {
     alias: aliases,
@@ -203,9 +204,11 @@ module.exports = merge(commonConfig, {
   devServer: {
     host: '0.0.0.0',
     port: process.env.PORT || 8080,
-    historyApiFallback: true,
+    historyApiFallback: {
+      index: path.join(PUBLIC_PATH, 'index.html'),
+    },
     hot: true,
     inline: true,
-    publicPath: process.env.PUBLIC_PATH || '/',
+    publicPath: PUBLIC_PATH,
   },
 });


### PR DESCRIPTION
Using the new changes on the MFE caused me some troubles when I tried to use a custom path in the devstack due to historyApiFallback is not configured to use the publicPath, this PR aims to solve that problem.

I applied the solution suggested in https://github.com/webpack/webpack-dev-server/issues/1457#issuecomment-415527819, and it worked!