### PR TITLE
fix(deps): upgrade dotenv-webpack to v4 to resolve errors with setImmediate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7213,9 +7213,9 @@
       }
     },
     "dotenv-webpack": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-3.0.0.tgz",
-      "integrity": "sha512-HsBTgVbh9E71IdC6QcQTnAuVt11niA5QMKblcBqhVBxP975XPGMqxf21pqgVBPyRKn2GqPh5kSHMgjxeR/HEAA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-4.0.0.tgz",
+      "integrity": "sha512-nmfhB0fV1AJVLGrU0E+F+/mfcP8dYAqiuFPgepQmX8D0uZoynxC1AYdlBn3fiA3Cfr9h0efFftprDfSS/C3kkg==",
       "requires": {
         "dotenv-defaults": "^2.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "css-loader": "3.6.0",
     "cssnano": "4.1.10",
     "dotenv": "8.2.0",
-    "dotenv-webpack": "3.0.0",
+    "dotenv-webpack": "4.0.0",
     "eslint": "6.8.0",
     "eslint-config-airbnb": "18.1.0",
     "eslint-plugin-import": "2.20.1",


### PR DESCRIPTION
Upgrading `dotenv-webpack` to v3.0.0 introduced an issue where a `setImmediate` error is thrown in the console. This PR upgrades `dotenv-webpack` to v4.0.0 which was recently released with the fix for this issue.

See the following for more details:
* https://stackoverflow.com/questions/64232479/vue-js-webpack-i-get-setimmediate-js80-uncaught-syntaxerror-unexpected-token
* https://github.com/mrsteele/dotenv-webpack/issues/240