### PR TITLE
fix: ensure publicPath works with HtmlWebpackPlugin

### DIFF
--- a/config/webpack.dev-stage.config.js
+++ b/config/webpack.dev-stage.config.js
@@ -127,6 +127,7 @@ module.exports = merge(commonConfig, {
     new HtmlWebpackPlugin({
       inject: true, // Appends script tags linking to the webpack bundles at the end of the body
       template: path.resolve(process.cwd(), 'public/index.html'),
+      publicPath: process.env.PUBLIC_PATH || 'auto',
     }),
     new Dotenv({
       path: path.resolve(process.cwd(), '.env.development-stage'),

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -188,6 +188,7 @@ module.exports = merge(commonConfig, {
     new HtmlWebpackPlugin({
       inject: true, // Appends script tags linking to the webpack bundles at the end of the body
       template: path.resolve(process.cwd(), 'public/index.html'),
+      publicPath: process.env.PUBLIC_PATH || 'auto',
     }),
     new Dotenv({
       path: path.resolve(process.cwd(), '.env.development'),

--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -158,6 +158,7 @@ module.exports = merge(commonConfig, {
       inject: true, // Appends script tags linking to the webpack bundles at the end of the body
       template: path.resolve(process.cwd(), 'public/index.html'),
       OPTIMIZELY_PROJECT_ID: process.env.OPTIMIZELY_PROJECT_ID || null,
+      publicPath: process.env.PUBLIC_PATH || 'auto',
     }),
     new Dotenv({
       path: path.resolve(process.cwd(), '.env'),


### PR DESCRIPTION
The default value is “`auto`” rather than “`/`“ like the other places we’re using PUBLIC_PATH.

Without this, HtmlWebpackPlugin doesn’t generate proper paths to where the assets are being served.  If PUBLIC_PATH is set to “foobar”, it will still look for main at /main.js, rather than /foobar/main.js