### PR TITLE
autoprefix css in dev builds

### DIFF
--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -8,6 +8,7 @@ const Dotenv = require('dotenv-webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const webpack = require('webpack');
 const PostCssRtlPlugin = require('postcss-rtl');
+const PostCssAutoprefixerPlugin = require('autoprefixer');
 
 const commonConfig = require('./webpack.common.config.js');
 const presets = require('../lib/presets');
@@ -60,7 +61,10 @@ module.exports = Merge.smart(commonConfig, {
           {
             loader: 'postcss-loader',
             options: {
-              plugins: () => [PostCssRtlPlugin()],
+              plugins: () => [
+                PostCssRtlPlugin(),
+                PostCssAutoprefixerPlugin({ grid: true }),
+              ],
             },
           },
           'resolve-url-loader',


### PR DESCRIPTION
This commit adds the css auto-prefixer into the dev postcss webpack routine, in order to assure that code loads the same style values in production and development.