### PR TITLE
feat: allow private overrides of dev env vars

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -136,6 +136,18 @@ Note that the "dir" and "dist" keys give you granular control over the shape of 
 
 This mechanism uses Webpack resolve aliases, as documented here: https://webpack.js.org/configuration/resolve/#resolvealias
 
+Override default .env.development environment variables with .env.private
+-------------------------------------------------------------------------
+
+In some situations, you may want to override development environment variables defined in .env.development
+with private environment variables that should never be checked into a repository. For example, a
+.env.development file may contain secrets for a third-party service (e.g., Algolia) that you'd like to use
+during development but want to ensure these secrets are not checked into Git.
+
+You may create a `.env.private` with any overrides of the environment settings configured in `.env.development`.
+
+**Note: .env.private should be added to your project's .gitignore so it does not get checked in.**
+
 Development
 -----------
 

--- a/config/webpack.dev-stage.config.js
+++ b/config/webpack.dev-stage.config.js
@@ -11,11 +11,17 @@ const PostCssRtlPlugin = require('postcss-rtl');
 
 const commonConfig = require('./webpack.common.config.js');
 const presets = require('../lib/presets');
+const resolvePrivateEnvConfig = require('../lib/resolvePrivateEnvConfig');
 
 // Add process env vars. Currently used only for setting the server port
 dotenv.config({
   path: path.resolve(process.cwd(), '.env.development-stage'),
 });
+
+// Allow private/local overrides of env vars from .env.development for config settings
+// that you'd like to persist locally during development, without the risk of checking
+// in temporary modifications to .env.development.
+resolvePrivateEnvConfig('.env.private');
 
 module.exports = merge(commonConfig, {
   mode: 'development',

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -12,12 +12,18 @@ const PostCssAutoprefixerPlugin = require('autoprefixer');
 
 const commonConfig = require('./webpack.common.config.js');
 const presets = require('../lib/presets');
+const resolvePrivateEnvConfig = require('../lib/resolvePrivateEnvConfig');
 
 // Add process env vars. Currently used only for setting the
 // server port and the publicPath
 dotenv.config({
   path: path.resolve(process.cwd(), '.env.development'),
 });
+
+// Allow private/local overrides of env vars from .env.development for config settings
+// that you'd like to persist locally during development, without the risk of checking
+// in temporary modifications to .env.development.
+resolvePrivateEnvConfig('.env.private');
 
 /*
 This function reads in a 'module.config.js' file if it exists and uses its contents to define

--- a/lib/resolvePrivateEnvConfig.js
+++ b/lib/resolvePrivateEnvConfig.js
@@ -1,0 +1,15 @@
+// Allow private/local overrides of env vars from .env.development(-stage) for config settings
+// that you'd like to persist locally during development, without the risk of checking
+// in temporary modifications to .env.development(-stage).
+
+const fs = require('fs');
+const dotenv = require('dotenv');
+
+module.exports = (filePath) => {
+  if (fs.existsSync(filePath)) {
+    const privateEnvConfig = dotenv.parse(fs.readFileSync(filePath));
+    Object.entries(privateEnvConfig).forEach(([key, value]) => {
+      process.env[key] = value;
+    });
+  }
+};


### PR DESCRIPTION
This PR adds support for the proposed feature as outlined in: https://github.com/edx/frontend-build/issues/140

You may now create a `.gitignored`'ed .env.private file in any repo that uses edx/frontend-build's Webpack configs to override environment variables defined in .env.development and .env.development-stage.