### PR TITLE
fix: configure webpackHotDevClient properly

### DIFF
--- a/config/webpack.dev-stage.config.js
+++ b/config/webpack.dev-stage.config.js
@@ -151,7 +151,15 @@ module.exports = merge(commonConfig, {
     port: process.env.PORT || 8080,
     https: true,
     historyApiFallback: true,
+    // Enable hot reloading server. It will provide WDS_SOCKET_PATH endpoint
+    // for the WebpackDevServer client so it can learn when the files were
+    // updated. The WebpackDevServer client is included as an entry point
+    // in the webpack development configuration. Note that only changes
+    // to CSS are currently hot reloaded. JS changes will refresh the browser.
     hot: true,
+    // Use 'ws' instead of 'sockjs-node' on server since we're using native
+    // websockets in `webpackHotDevClient`.
+    transportMode: 'ws',
     inline: true,
     publicPath: '/',
     disableHostCheck: true,

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -229,7 +229,15 @@ module.exports = merge(commonConfig, {
     historyApiFallback: {
       index: path.join(PUBLIC_PATH, 'index.html'),
     },
+    // Enable hot reloading server. It will provide WDS_SOCKET_PATH endpoint
+    // for the WebpackDevServer client so it can learn when the files were
+    // updated. The WebpackDevServer client is included as an entry point
+    // in the webpack development configuration. Note that only changes
+    // to CSS are currently hot reloaded. JS changes will refresh the browser.
     hot: true,
+    // Use 'ws' instead of 'sockjs-node' on server since we're using native
+    // websockets in `webpackHotDevClient`.
+    transportMode: 'ws',
     inline: true,
     publicPath: PUBLIC_PATH,
   },


### PR DESCRIPTION
We’ve been seeing errors in MFEs using frontend-build 5.6.10 where they were unable to connect to webpack-dev-server for hot reloading, and it was making the server shut down.

The server would error out with:

```
events.js:292
      throw er; // Unhandled 'error' event
      ^

Error: read ECONNRESET
    at TCP.onStreamRead (internal/stream_base_commons.js:205:27)
Emitted 'error' event on Socket instance at:
    at emitErrorNT (internal/streams/destroy.js:92:8)
    at emitErrorAndCloseNT (internal/streams/destroy.js:60:3)
    at processTicksAndRejections (internal/process/task_queues.js:84:21) {
  errno: 'ECONNRESET',
  code: 'ECONNRESET',
  syscall: 'read'
}
```
And the client would error out with a message like:

```
WebSocket connection to 'ws://localhost:8735/sockjs-node' failed:
```

The fix was to set `transportMode` to `'ws’` in our dev webpack configs.  I also added some comments straight out of react-scripts to what the `hot` value means, since it seemed helpful.