### PR TITLE
feat: use NewRelicSourceMapPlugin to upload source maps to New Relic

### DIFF
--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -6,6 +6,7 @@ const dotenv = require('dotenv');
 const Dotenv = require('dotenv-webpack');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const HtmlWebpackNewRelicPlugin = require('html-webpack-new-relic-plugin');
+const NewRelicSourceMapPlugin = require('new-relic-source-map-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
@@ -173,6 +174,13 @@ module.exports = merge(commonConfig, {
       trustKey: process.env.NEW_RELIC_TRUST_KEY || 'undefined_trust_key',
       licenseKey: process.env.NEW_RELIC_LICENSE_KEY || 'undefined_license_key',
       applicationID: process.env.NEW_RELIC_APP_ID || 'undefined_application_id',
+    }),
+    new NewRelicSourceMapPlugin({
+      applicationId: process.env.NEW_RELIC_APP_ID,
+      nrAdminKey: process.env.NEW_RELIC_ADMIN_KEY,
+      staticAssetUrl: process.env.BASE_URL,
+      // upload source maps in prod builds only
+      noop: typeof process.env.NEW_RELIC_ADMIN_KEY === 'undefined',
     }),
     new BundleAnalyzerPlugin({
       analyzerMode: 'static',

--- a/package-lock.json
+++ b/package-lock.json
@@ -4995,13 +4995,6 @@
             "electron-to-chromium": "^1.3.634",
             "escalade": "^3.1.1",
             "node-releases": "^1.1.69"
-          },
-          "dependencies": {
-            "caniuse-lite": {
-              "version": "1.0.30001179",
-              "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001179.tgz",
-              "integrity": "sha512-blMmO0QQujuUWZKyVrD1msR4WNDAqb/UPO1Sw2WWsQ7deoM5bJiicKnWJ1Y0NS/aGINSnKPIWBMw5luX+NDUCA=="
-            }
           }
         },
         "electron-to-chromium": {
@@ -6201,9 +6194,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001146",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001146.tgz",
-      "integrity": "sha512-VAy5RHDfTJhpxnDdp2n40GPPLp3KqNrXz1QqFv4J64HvArKs8nuNMOWkB3ICOaBTU/Aj4rYAo/ytdQDDFF/Pug=="
+      "version": "1.0.30001239",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001239.tgz",
+      "integrity": "sha512-cyBkXJDMeI4wthy8xJ2FvDU6+0dtcZSJW3voUF8+e9f1bBeuvyZfc3PNbkOETyhbR+dGCPzn9E7MA3iwzusOhQ=="
     },
     "capture-exit": {
       "version": "2.0.0",


### PR DESCRIPTION
Utilizes the already installed `NewRelicSourceMapPlugin` NPM package in webpack.prod.config.js to upload source maps to New Relic for production builds.

With source maps uploaded to New Relic, viewing the unminified stack trace for JS errors occurs automatically as opposed to needing to manually upload a source map file.