### PR TITLE
feat: use new jsx transform

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+coverage/*
+dist/
+node_modules/
+__mocks__/
+__snapshots__/

--- a/config/babel.config.js
+++ b/config/babel.config.js
@@ -1,7 +1,11 @@
 module.exports = {
   presets: [
     '@babel/preset-env',
-    '@babel/preset-react',
+    [
+      '@babel/preset-react', {
+        runtime: 'automatic',
+      },
+    ],
   ],
   plugins: [
     '@babel/plugin-proposal-object-rest-spread',

--- a/example/package.json
+++ b/example/package.json
@@ -14,8 +14,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "react": "^16.14.0",
+    "react-dom": "^16.14.0"
   },
   "devDependencies": {
     "react-test-renderer": "16.13.1"

--- a/example/src/App.jsx
+++ b/example/src/App.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import appleUrl, { ReactComponent as Apple } from './apple.svg';
 import appleImg from './apple.jpg';
 

--- a/example/src/App.test.jsx
+++ b/example/src/App.test.jsx
@@ -1,5 +1,4 @@
 /* eslint-disable global-require */
-import React from 'react';
 import renderer from 'react-test-renderer';
 import App from './App';
 

--- a/example/src/index.jsx
+++ b/example/src/index.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1556,9 +1556,9 @@
       "integrity": "sha512-Fxt+AfXgjMoin2maPIYzFZnQjAXjAL0PHscM5pRTtatFqB+vZxAM9tLp2Optnuw3QOQC40jTNeGYFOMvyf7v9g=="
     },
     "@edx/eslint-config": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@edx/eslint-config/-/eslint-config-1.1.6.tgz",
-      "integrity": "sha512-5+WPYySI8wGttJ+eU6SqCNZk/smABmYF5V+jJdhtV6+zZ6PjaZ4JNLyKNFIAht6lc5Ld8AG8Ki50YTuMd0j+fg=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@edx/eslint-config/-/eslint-config-1.2.0.tgz",
+      "integrity": "sha512-zvI9kCZ7c13uNhAZ2fwYWp7deOd52oPHSv223MzoeK5ZQgZyTIamH02mToNBWLqkPC4zi7bsaHvLSxy4wDKzug=="
     },
     "@formatjs/ecma402-abstract": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@babel/plugin-syntax-dynamic-import": "7.8.3",
     "@babel/preset-env": "7.10.4",
     "@babel/preset-react": "7.10.4",
-    "@edx/eslint-config": "1.1.6",
+    "@edx/eslint-config": "1.2.0",
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.0-rc.2",
     "@svgr/webpack": "5.5.0",
     "autoprefixer": "10.2.6",
@@ -81,5 +81,8 @@
   "devDependencies": {
     "@commitlint/cli": "11.0.0",
     "@commitlint/config-angular": "11.0.0"
+  },
+  "peerDependencies": {
+    "react": "^16.14.0 || ^17.0.0"
   }
 }


### PR DESCRIPTION
This updates the @babel/preset-react configuration to use the new JSX transform, which no longer requires `React` to be imported into source files.

It also updates our eslint-config to no longer require that `React` be imported into source files as well.

This works because our babel (7.9.0+) and react (16.14.0+) versions are high enough that they can take advantage of the new JSX transform.

Note that this means this version of frontend-build has a new peer dependency on react > 16.14.0, to ensure that it has the new JSX transform available.