### PR TITLE
fix: update devServer config to use webSocketServer

### DIFF
--- a/config/webpack.dev-stage.config.js
+++ b/config/webpack.dev-stage.config.js
@@ -180,9 +180,7 @@ module.exports = merge(commonConfig, {
     // in the webpack development configuration. Note that only changes
     // to CSS are currently hot reloaded. JS changes will refresh the browser.
     hot: true,
-    // Use 'ws' instead of 'sockjs-node' on server since we're using native
-    // websockets in `webpackHotDevClient`.
-    transportMode: 'ws',
+    webSocketServer: 'ws',
     devMiddleware: {
       publicPath: PUBLIC_PATH,
     },

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -179,9 +179,7 @@ module.exports = merge(commonConfig, {
     // in the webpack development configuration. Note that only changes
     // to CSS are currently hot reloaded. JS changes will refresh the browser.
     hot: true,
-    // Use 'ws' instead of 'sockjs-node' on server since we're using native
-    // websockets in `webpackHotDevClient`.
-    transportMode: 'ws',
+    webSocketServer: 'ws',
     devMiddleware: {
       publicPath: PUBLIC_PATH,
     },


### PR DESCRIPTION
v4 of webpack-dev-server has a breaking change where the 'transportMode' configuration for the dev server was changed to 'webSocketServer', effectively.

See migration guide here: https://github.com/webpack/webpack-dev-server/blob/master/migration-v4.md