### PR TITLE
fix: upgrade edx/new-relic-source-map-webpack-plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1561,9 +1561,9 @@
       "integrity": "sha512-zvI9kCZ7c13uNhAZ2fwYWp7deOd52oPHSv223MzoeK5ZQgZyTIamH02mToNBWLqkPC4zi7bsaHvLSxy4wDKzug=="
     },
     "@edx/new-relic-source-map-webpack-plugin": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@edx/new-relic-source-map-webpack-plugin/-/new-relic-source-map-webpack-plugin-1.0.0.tgz",
-      "integrity": "sha512-6z7EQxQGl/SvX2ivHxhTEgn56fU3c99kEDPbJdp8s80IWoiMN+Yq46hfCW/J0fiN1qsJsNNNAdwWlgChg/4aLQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@edx/new-relic-source-map-webpack-plugin/-/new-relic-source-map-webpack-plugin-1.0.1.tgz",
+      "integrity": "sha512-SAwugqBvDUg7ANdu1uBCkpPp0MnBlfyYAvKwO6Jh6Q4tMIPN6U35IF7MAymn1EZmi28UV6sLpSQPLggQjVQknA==",
       "requires": {
         "@newrelic/publish-sourcemap": "^5.0.1"
       }
@@ -2181,14 +2181,19 @@
       }
     },
     "@newrelic/publish-sourcemap": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@newrelic/publish-sourcemap/-/publish-sourcemap-5.0.1.tgz",
-      "integrity": "sha512-eXkc7+RAPJPVBhgYrJWq2nLUDDj1yrgM1yyaT6kDbczZe+NtecOwc3m3yx2WCkVRiAaSANQrKdUsbKkoqt5msg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/publish-sourcemap/-/publish-sourcemap-5.1.0.tgz",
+      "integrity": "sha512-pOpW0InKZp/DXUmD3h6vaCGdtMDY5LyzzKvq3S3MBwTKm5Qc5ka3yZC73sLAMOXnjKZmdyG3d8A5LC+LawOEpA==",
       "requires": {
         "superagent": "^3.4.1",
         "yargs": "^16.0.3"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2221,11 +2226,11 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "requires": {
-            "ansi-regex": "^5.0.0"
+            "ansi-regex": "^5.0.1"
           }
         },
         "wrap-ansi": {
@@ -4974,9 +4979,9 @@
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "cookiejar": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
-      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
+      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ=="
     },
     "copy-descriptor": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@babel/preset-env": "7.10.4",
     "@babel/preset-react": "7.10.4",
     "@edx/eslint-config": "1.2.0",
-    "@edx/new-relic-source-map-webpack-plugin": "1.0.0",
+    "@edx/new-relic-source-map-webpack-plugin": "1.0.1",
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.0-rc.2",
     "@svgr/webpack": "5.5.0",
     "autoprefixer": "10.2.6",


### PR DESCRIPTION
Bumps version of `@edx/new-relic-source-map-webpack-plugin` to resolve a deprecation warning. It looks like the underlying `@newrelic/publish-sourcemap` is also bumped from 5.0.1 to 5.1.0, which _may_ help fix the auth-error we're seeing on production builds in our GoCD build pipelines? 🤔 