### PR TITLE
fix: add NODE_ENV variable to dev html webpack plugin

### DIFF
--- a/config/webpack.dev-stage.config.js
+++ b/config/webpack.dev-stage.config.js
@@ -153,6 +153,8 @@ module.exports = merge(commonConfig, {
       inject: true, // Appends script tags linking to the webpack bundles at the end of the body
       template: path.resolve(process.cwd(), 'public/index.html'),
       FAVICON_URL: process.env.FAVICON_URL || null,
+      OPTIMIZELY_PROJECT_ID: process.env.OPTIMIZELY_PROJECT_ID || null,
+      NODE_ENV: process.env.NODE_ENV || null,
     }),
     new Dotenv({
       path: path.resolve(process.cwd(), '.env.development-stage'),

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -154,6 +154,7 @@ module.exports = merge(commonConfig, {
       template: path.resolve(process.cwd(), 'public/index.html'),
       FAVICON_URL: process.env.FAVICON_URL || null,
       OPTIMIZELY_PROJECT_ID: process.env.OPTIMIZELY_PROJECT_ID || null,
+      NODE_ENV: process.env.NODE_ENV || null,
     }),
     new Dotenv({
       path: path.resolve(process.cwd(), '.env.development'),

--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -189,6 +189,7 @@ module.exports = merge(commonConfig, {
       template: path.resolve(process.cwd(), 'public/index.html'),
       FAVICON_URL: process.env.FAVICON_URL || null,
       OPTIMIZELY_PROJECT_ID: process.env.OPTIMIZELY_PROJECT_ID || null,
+      NODE_ENV: process.env.NODE_ENV || null,
     }),
     new Dotenv({
       path: path.resolve(process.cwd(), '.env'),


### PR DESCRIPTION
This will allow us to do something like so in `index.html`:
```
<% if (htmlWebpackPlugin.options.NODE_ENV === 'production' && htmlWebpackPlugin.options.OPTIMIZELY_PROJECT_ID) { %>
      <script src="https://www.edx.org/optimizelyjs/<%= htmlWebpackPlugin.options.OPTIMIZELY_PROJECT_ID %>.js"></script>
    <% } %>
```
(such a thing is necessary because the prod optimizely script lives in the edx CDN; the dev and stage optimizely scripts do not).