### PR TITLE
feat: faster babel-loader by excluding node_module

### DIFF
--- a/config/webpack.dev-stage.config.js
+++ b/config/webpack.dev-stage.config.js
@@ -47,7 +47,7 @@ module.exports = merge(commonConfig, {
       // Babel is configured with the .babelrc file at the root of the project.
       {
         test: /\.(js|jsx)$/,
-        exclude: /node_modules\/(?!@(open)?edx)/,
+        exclude: /node_modules/,
         use: {
           loader: 'babel-loader',
           options: {

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -90,7 +90,7 @@ module.exports = merge(commonConfig, {
       // Babel is configured with the .babelrc file at the root of the project.
       {
         test: /\.(js|jsx|ts|tsx)$/,
-        exclude: /node_modules\/(?!@(open)?edx)/,
+        exclude: /node_modules/,
         use: {
           loader: 'babel-loader',
           options: {

--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -71,7 +71,7 @@ module.exports = merge(commonConfig, {
       // Babel is configured with the .babelrc file at the root of the project.
       {
         test: /\.(js|jsx|ts|tsx)$/,
-        exclude: /node_modules\/(?!@(open)?edx)/,
+        exclude: /node_modules/,
         use: {
           loader: 'babel-loader',
           options: {


### PR DESCRIPTION
The role of `babel-loader` is twofold:

- Compile jsx (react) assets to js
- Make js assets compatible with older browsers

See the official documentation here: https://webpack.js.org/loaders/babel-loader/

It is widely recommended to exclude files in node_modules/ from that loader. See for instance: https://webpack.js.org/loaders/babel-loader/#babel-loader-is-slow Indeed, such files are assumed to be already compatible with older browsers, and built from jsx.

However, the base configuration in frontend-build had the following `exclude` directive:

    exclude: /node_modules\/(?!@(open)?edx)/,

Which means that only `@openedx` and `@edx` assets were excluded.

With this change, we reduce the build time significantly for all MFEs. For instance:

- frontend-app-profile: 86s -> 64s (-26%)
- frontend-app-learning: 167s -> 110s (-34%)

We observe a change in the fingerprint of app.js and app.css, but we don't consider these changes to be significant. The generated MFEs still worked when we tested them. If we realize later that some modules need to be compiled with babel, then we should explicitly include them with `and` directives, as documented here: https://webpack.js.org/loaders/babel-loader/#some-files-in-my-node_modules-are-not-transpiled-for-ie-11