### PR TITLE
fix!: [DEPR] Cleanup New Relic Source Map Webpack Plugin

### DIFF
--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -8,7 +8,6 @@ const { merge } = require('webpack-merge');
 const CssNano = require('cssnano');
 const Dotenv = require('dotenv-webpack');
 const dotenv = require('dotenv');
-const NewRelicSourceMapPlugin = require('@edx/new-relic-source-map-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const path = require('path');
@@ -46,13 +45,6 @@ if (process.env.ENABLE_NEW_RELIC !== 'false') {
     trustKey: process.env.NEW_RELIC_TRUST_KEY || 'undefined_trust_key',
     licenseKey: process.env.NEW_RELIC_LICENSE_KEY || 'undefined_license_key',
     applicationID: process.env.NEW_RELIC_APP_ID || 'undefined_application_id',
-  }));
-  extraPlugins.push(new NewRelicSourceMapPlugin({
-    applicationId: process.env.NEW_RELIC_APP_ID,
-    apiKey: process.env.NEW_RELIC_ADMIN_KEY,
-    staticAssetUrl: process.env.BASE_URL,
-    // upload source maps in prod builds only
-    noop: typeof process.env.NEW_RELIC_ADMIN_KEY === 'undefined',
   }));
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "@babel/preset-env": "7.24.8",
         "@babel/preset-react": "7.26.3",
         "@edx/eslint-config": "^4.3.0",
-        "@edx/new-relic-source-map-webpack-plugin": "2.1.0",
         "@edx/typescript-config": "1.1.0",
         "@formatjs/cli": "^6.0.3",
         "@fullhuman/postcss-purgecss": "5.0.0",
@@ -2055,15 +2054,6 @@
         "eslint-plugin-jsx-a11y": "^6.2.3",
         "eslint-plugin-react": "^7.18.0",
         "eslint-plugin-react-hooks": "^1.7.0 || ^4.0.0"
-      }
-    },
-    "node_modules/@edx/new-relic-source-map-webpack-plugin": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@edx/new-relic-source-map-webpack-plugin/-/new-relic-source-map-webpack-plugin-2.1.0.tgz",
-      "integrity": "sha512-OrlvtdsPcWuOm6NBWfUxFE06qdPiu2bf9nU4I9t8Lu7WW6NsosAB5hxm5U+MBMZP2AuVl3FAt0k0lZsu3+ri8Q==",
-      "license": "AGPL-3.0",
-      "dependencies": {
-        "@newrelic/publish-sourcemap": "^5.0.1"
       }
     },
     "node_modules/@edx/typescript-config": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@babel/preset-env": "7.24.8",
     "@babel/preset-react": "7.26.3",
     "@edx/eslint-config": "^4.3.0",
-    "@edx/new-relic-source-map-webpack-plugin": "2.1.0",
     "@edx/typescript-config": "1.1.0",
     "@formatjs/cli": "^6.0.3",
     "@fullhuman/postcss-purgecss": "5.0.0",


### PR DESCRIPTION
Removed new-relic-source-map-webpack-plugin imports/requires from all webpack configuration files. Cleaned up plugin configurations and related code. Removed any associated New Relic source map upload functionality