### PR TITLE
fix: remove obsolete mixed-decls from silenceDeprecations

### DIFF
--- a/config/webpack.dev-stage.config.js
+++ b/config/webpack.dev-stage.config.js
@@ -104,7 +104,7 @@ module.exports = merge(commonConfig, {
                 ],
                 // Silences compiler deprecation warnings. They mostly come from bootstrap and/or paragon.
                 quietDeps: true,
-                silenceDeprecations: ['abs-percent', 'color-functions', 'import', 'mixed-decls', 'global-builtin', 'legacy-js-api'],
+                silenceDeprecations: ['abs-percent', 'color-functions', 'import', 'global-builtin', 'legacy-js-api'],
               },
             },
           },

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -68,7 +68,7 @@ function getStyleUseConfig() {
           ],
           // Silences compiler deprecation warnings. They mostly come from bootstrap and/or paragon.
           quietDeps: true,
-          silenceDeprecations: ['abs-percent', 'color-functions', 'import', 'mixed-decls', 'global-builtin', 'legacy-js-api'],
+          silenceDeprecations: ['abs-percent', 'color-functions', 'import', 'global-builtin', 'legacy-js-api'],
         },
       },
     },

--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -135,7 +135,7 @@ module.exports = merge(commonConfig, {
                 ],
                 // Silences compiler deprecation warnings. They mostly come from bootstrap and/or paragon.
                 quietDeps: true,
-                silenceDeprecations: ['abs-percent', 'color-functions', 'import', 'mixed-decls', 'global-builtin', 'legacy-js-api'],
+                silenceDeprecations: ['abs-percent', 'color-functions', 'import', 'global-builtin', 'legacy-js-api'],
               },
             },
           },


### PR DESCRIPTION
### Description

The `mixed-decls` Sass deprecation became obsolete in Dart Sass 1.85.0. Since `frontend-build` pins `sass` at 1.85.1, silencing it now causes its own warning in downstream MFE builds. The other `silenceDeprecations` entries remain valid for the current Sass version.

Fixes #682

### Testing

To reproduce the problem, run `npm run dev` in `frontend-app-learning`. You should see warnings like:

```
Module Warning (from ./node_modules/sass-loader/dist/cjs.js):
mixed-decls deprecation is obsolete. If you were previously silencing it, your code may now behave in unexpected ways.
```

To test the fix, `cd` to your local `frontend-build` checkout on this branch and pack a tarball:

```bash
npm version 14.6.4 --no-git-tag-version && npm pack
```

Then install it in `frontend-app-learning`:

```bash
npm install ../frontend-build/openedx-frontend-build-14.6.4.tgz
```

Run `npm run dev` again and confirm the `mixed-decls` warnings are gone.

### LLM usage notice

Built with assistance from Claude.